### PR TITLE
Update yelmo/yelmox repo links from palma-ice to fesmc org

### DIFF
--- a/docs/example-programs.md
+++ b/docs/example-programs.md
@@ -26,4 +26,4 @@ Clone the repository from [https://github.com/palma-ice/yelmot](https://github.c
 This setup is suitable for glacial-cycle simulations, future simulations
 or any other typical (realistic) ice-sheet model simulation.
 
-Clone the repository from [https://github.com/palma-ice/yelmox](https://github.com/palma-ice/yelmox)
+Clone the repository from [https://github.com/fesmc/yelmox](https://github.com/fesmc/yelmox)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,12 +39,12 @@ Follow the steps below to (1) obtain the code, (2) configure the Makefile for yo
 
 ### 1. Get the code
 
-Clone the repository from [https://github.com/palma-ice/yelmo](https://github.com/palma-ice/yelmo):
+Clone the repository from [https://github.com/fesmc/yelmo](https://github.com/fesmc/yelmo):
 
 ```bash
 # Clone repository
-git clone https://github.com/palma-ice/yelmo.git $YELMOROOT
-git clone git@github.com:palma-ice/yelmo.git  $YELMOROOT # via ssh
+git clone https://github.com/fesmc/yelmo.git $YELMOROOT
+git clone git@github.com:fesmc/yelmo.git  $YELMOROOT # via ssh
 
 cd $YELMOROOT
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ The physics and design of **Yelmo** are described in the following article:
 > Robinson, A., Alvarez-Solas, J., Montoya, M., Goelzer, H., Greve, R., and Ritz, C.: Description and validation of the ice-sheet model Yelmo (version 1.0), Geosci. Model Dev., 13, 2805–2823, [https://doi.org/10.5194/gmd-13-2805-2020](https://doi.org/10.5194/gmd-13-2805-2020), 2020.
 
 The Yelmo code repository can be found here:
-[https://github.com/palma-ice/yelmo](https://github.com/palma-ice/yelmo)
+[https://github.com/fesmc/yelmo](https://github.com/fesmc/yelmo)
 
 ## General model structure - classes and usage
 

--- a/docs/physics/mass_conservation/index.md
+++ b/docs/physics/mass_conservation/index.md
@@ -5,11 +5,11 @@ depth-averaged horizontal velocity $\bar{\mathbf u} = (\bar u, \bar v)$
 from the [momentum balance](../momentum/diva.md) and a set of
 **mass-balance inputs** (surface, basal, frontal, calving). The
 implementation lives in
-[`src/physics/mass_conservation.f90`](https://github.com/palma-ice/yelmo/blob/main/src/physics/mass_conservation.f90),
+[`src/physics/mass_conservation.f90`](https://github.com/fesmc/yelmo/blob/main/src/physics/mass_conservation.f90),
 with the advection step delegated to
-[`src/physics/solver_advection.f90`](https://github.com/palma-ice/yelmo/blob/main/src/physics/solver_advection.f90)
+[`src/physics/solver_advection.f90`](https://github.com/fesmc/yelmo/blob/main/src/physics/solver_advection.f90)
 and the per-timestep driver in
-[`src/yelmo_topography.f90`](https://github.com/palma-ice/yelmo/blob/main/src/yelmo_topography.f90).
+[`src/yelmo_topography.f90`](https://github.com/fesmc/yelmo/blob/main/src/yelmo_topography.f90).
 
 ## Continuity equation
 

--- a/docs/physics/momentum/diva.md
+++ b/docs/physics/momentum/diva.md
@@ -208,6 +208,6 @@ $$
   $\frac{\partial u}{\partial z}$ reproduces the SIA velocity profile —
   see [SIA](sia.md).
 
-[diva_src]: https://github.com/palma-ice/yelmo/blob/main/src/physics/velocity_diva.f90
-[diva_taud]: https://github.com/palma-ice/yelmo/blob/main/src/physics/velocity_general.f90
-[diva_visc]: https://github.com/palma-ice/yelmo/blob/main/src/physics/deformation.f90
+[diva_src]: https://github.com/fesmc/yelmo/blob/main/src/physics/velocity_diva.f90
+[diva_taud]: https://github.com/fesmc/yelmo/blob/main/src/physics/velocity_general.f90
+[diva_visc]: https://github.com/fesmc/yelmo/blob/main/src/physics/deformation.f90

--- a/docs/physics/momentum/sia.md
+++ b/docs/physics/momentum/sia.md
@@ -3,7 +3,7 @@
 The SIA is the complementary limit to SSA: membrane stresses are
 neglected and the horizontal stress balance is dominated by the basal
 drag exerted by vertical shear. Yelmo's SIA solver is implemented in
-[`src/physics/velocity_sia.f90`](https://github.com/palma-ice/yelmo/blob/main/src/physics/velocity_sia.f90)
+[`src/physics/velocity_sia.f90`](https://github.com/fesmc/yelmo/blob/main/src/physics/velocity_sia.f90)
 and is used to provide the vertical-shear contribution to the velocity
 field in the hybrid SIA + SSA mode and as a diagnostic on its own.
 

--- a/docs/physics/momentum/solvers.md
+++ b/docs/physics/momentum/solvers.md
@@ -196,5 +196,5 @@ The Picard loop, the viscosity update, the F-integral closure and the
 basal-stress and 3D velocity diagnostics are identical between the two
 solvers: only the linear-system assembly differs.
 
-[resid_src]: https://github.com/palma-ice/yelmo/blob/main/src/physics/solver_ssa_ac.f90
-[energy_src]: https://github.com/palma-ice/yelmo/blob/main/src/physics/solver_ssa_ac_energy.f90
+[resid_src]: https://github.com/fesmc/yelmo/blob/main/src/physics/solver_ssa_ac.f90
+[energy_src]: https://github.com/fesmc/yelmo/blob/main/src/physics/solver_ssa_ac_energy.f90

--- a/docs/physics/momentum/ssa.md
+++ b/docs/physics/momentum/ssa.md
@@ -5,7 +5,7 @@ of vanishing vertical shear. It treats the ice column as a vertical plug:
 the horizontal velocity is independent of $z$, so $\bar{\mathbf u}$
 *is* the basal velocity, $\bar{\mathbf u} = \mathbf u_b$. The
 implementation is in
-[`src/physics/velocity_ssa.f90`](https://github.com/palma-ice/yelmo/blob/main/src/physics/velocity_ssa.f90).
+[`src/physics/velocity_ssa.f90`](https://github.com/fesmc/yelmo/blob/main/src/physics/velocity_ssa.f90).
 
 Yelmo uses the same depth-integrated 2D solver as DIVA — the difference
 is purely in the closure. SSA is the appropriate model for floating ice

--- a/docs/running-with-yelmox.md
+++ b/docs/running-with-yelmox.md
@@ -17,12 +17,12 @@ Also note, below it is assumed that you are setting up on the `pik_hpc2024` syst
 ```bash
 
 # yelmox
-git clone git@github.com:palma-ice/yelmox.git
+git clone git@github.com:fesmc/yelmox.git
 cd yelmox
 python3 config.py config/pik_hpc2024_ifx 
 
 # yelmo
-git clone git@github.com:palma-ice/yelmo.git
+git clone git@github.com:fesmc/yelmo.git
 cd yelmo
 python3 config.py config/pik_hpc2024_ifx
 ln -s $FESMUSRC ./

--- a/docs/running-yelmox-rembo.md
+++ b/docs/running-yelmox-rembo.md
@@ -6,14 +6,14 @@
 
 ```bash
 # Clone repository: YelmoX
-git clone https://github.com/palma-ice/yelmox.git
+git clone https://github.com/fesmc/yelmox.git
 
 # Clone yelmo into a sub-directory too
 cd yelmox
-git clone https://github.com/palma-ice/yelmo.git
+git clone https://github.com/fesmc/yelmo.git
 
 # Clone isostasy into a sub-directory too 
-git clone https://github.com/palma-ice/isostasy.git
+git clone https://github.com/palma-ice/FastIsostasy.git
 
 # Clone rembo into a sub-directory too 
 git clone https://github.com/alex-robinson/rembo1


### PR DESCRIPTION
## Summary
- Update all `palma-ice/yelmo` and `palma-ice/yelmox` GitHub URLs to `fesmc/yelmo` and `fesmc/yelmox` (repos were transferred to the fesmc org).
- Also bump `palma-ice/isostasy` → `palma-ice/FastIsostasy` in `running-yelmox-rembo.md` (the old `isostasy` repo is outdated).

## Test plan
- [ ] Spot-check links in the rendered site after `mkdocs gh-deploy`.